### PR TITLE
Fix last line parsing issue

### DIFF
--- a/parsecsv.lib.php
+++ b/parsecsv.lib.php
@@ -666,9 +666,16 @@ class parseCSV {
         $was_enclosed = false;
         $strlen       = strlen($data);
 
+        // force the parser to process end of data as a character (false) when
+        // data does not end with a line feed or carriage return character.
+        $lch = $data{$strlen-1};
+        if ($lch != "\n" && $lch != "\r") {
+            $strlen++;
+        }
+
         // walk through each character
         for ( $i=0; $i < $strlen; $i++ ) {
-            $ch  = $data{$i};
+            $ch  = ( isset($data{$i}) )   ? $data{$i}   : false ;
             $nch = ( isset($data{$i+1}) ) ? $data{$i+1} : false ;
             $pch = ( isset($data{$i-1}) ) ? $data{$i-1} : false ;
 
@@ -734,9 +741,9 @@ class parseCSV {
                     $enclosed = false;
                 }
 
-            // end of field/row
+            // end of field/row/csv
             }
-            elseif ( ($ch == $this->delimiter || $ch == "\n" || $ch == "\r") && !$enclosed ) {
+            elseif ( ($ch == $this->delimiter || $ch == "\n" || $ch == "\r" || $ch === false) && !$enclosed ) {
                 $key           = ( !empty($head[$col]) ) ? $head[$col] : $col ;
                 $row[$key]     = ( $was_enclosed ) ? $current : trim($current) ;
                 $current       = '';
@@ -744,7 +751,7 @@ class parseCSV {
                 $col++;
 
                 // end of row
-                if ( $ch == "\n" || $ch == "\r" ) {
+                if ( $ch == "\n" || $ch == "\r" || $ch === false ) {
                     if ( $this->_validate_offset($row_count) && $this->_validate_row_conditions($row, $this->conditions) ) {
                         if ( $this->heading && empty($head) ) {
                             $head = $row;


### PR DESCRIPTION
This fixes #22.

If CSV data didn't end with `\n`, `\r`, or `\r\n` the last line of the CSV would be ignored, as the parser wouldn't trigger end of row logic for the last row.

This change forces the parser to process the end of the CSV data as it's own character (false), and deals with end of data just like it treats end of row. In theory this should be more memory efficient than appending a line feed to the CSV data if needed.

@williamknauss I'll let you code review this, as I'm not 100% confident these changes don't cause any side-effects.

I've done some basic hacky testing with the following inputs:
- `name,age\nJohn,28\nJenn,25`
- `name,age\nJohn,28\nJenn,25\n`
- `name,age\rJohn,28\rJenn,25`
- `name,age\rJohn,28\rJenn,25\r`
- `name,age\r\nJohn,28\r\nJenn,25`
- `name,age\r\nJohn,28\r\nJenn,25\r\n`

And they all produce the same output:

```
Array
(
    [0] => Array
        (
            [name] => John
            [age] => 28
        )

    [1] => Array
        (
            [name] => Jenn
            [age] => 25
        )

)
```

Additionally mixing the use of `\n`, `\r`, and `\r\n` within the same CSV data works just fine too.
