### PR TITLE
GNU Make requires tab-indentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,14 @@ COMPOSER_BIN_DIR := vendor/bin
 PHPUNIT_ARGS = -c tests/phpunit.xml
 
 test: phpunit-dep
-    ${COMPOSER_BIN_DIR}/phpunit ${PHPUNIT_ARGS}
+	${COMPOSER_BIN_DIR}/phpunit ${PHPUNIT_ARGS}
 
 phpunit-dep:
-    test -f ${COMPOSER_BIN_DIR}/phpunit || ( \
-        echo "phpunit is required to run tests." \
-             "Please run: composer install" >&2 && \
-        exit 1 \
-    )
+	test -f ${COMPOSER_BIN_DIR}/phpunit || ( \
+	echo "phpunit is required to run tests." \
+		"Please run: composer install" >&2 && \
+	exit 1 \
+	)
 
 .SILENT:
 .PHONY: test phpunit-dep


### PR DESCRIPTION
GNU Make does not play nicely with leading spaces after rules. It
requires that the first line starts with a tab. Although it isn't
strictly necessary to change subsequent lines as well, mixing tabs and
spaces is a nightmare.
