### PR TITLE
Suppress file name too long warning

### DIFF
--- a/parsecsv.lib.php
+++ b/parsecsv.lib.php
@@ -405,7 +405,7 @@ class parseCSV {
                 $this->conditions = $conditions;
             }
 
-            if (is_readable($input)) {
+            if (strlen($input) <= PHP_MAXPATHLEN && is_readable($input)) {
                 $this->data = $this->parse_file($input);
             } else {
                 $this->file_data = &$input;


### PR DESCRIPTION
Suppress Warning: "File name is longer than the maximum allowed path length on this platform (4096)"
