### PR TITLE
Incorrect parsing with single quote during auto-detection delimiter.

### DIFF
--- a/parsecsv.lib.php
+++ b/parsecsv.lib.php
@@ -524,6 +524,8 @@ class parseCSV {
 
         if (is_null($enclosure)) {
             $enclosure = $this->enclosure;
+        } else {
+            $this->enclosure = $enclosure;
         }
 
         if (is_null($preferred)) {

--- a/tests/methods/auto_test.php
+++ b/tests/methods/auto_test.php
@@ -1,0 +1,26 @@
+<?php
+
+class auto_Test extends PHPUnit_Framework_TestCase
+{
+    public function autoQuotesDataProvider()
+    {
+        return array(
+            array('tests/methods/fixtures/auto-double-enclosure.csv', '"'),
+            array('tests/methods/fixtures/auto-single-enclosure.csv', "'"),
+        );
+    }
+
+    /**
+     * @dataProvider autoQuotesDataProvider
+     * 
+     * @param string $file
+     * @param string $enclosure
+     */
+    public function testAutoQuotes($file, $enclosure)
+    {
+        $csv = new parseCSV();
+        $csv->auto($file, true, null, null, $enclosure);
+        $this->assertArrayHasKey('column1', $csv->data[0], 'Data parsed incorrectly with enclosure ' . $enclosure);
+        $this->assertEquals('value1', $csv->data[0]['column1'], 'Data parsed incorrectly with enclosure ' . $enclosure);
+    }
+}

--- a/tests/methods/fixtures/auto-double-enclosure.csv
+++ b/tests/methods/fixtures/auto-double-enclosure.csv
@@ -1,0 +1,3 @@
+"column1","column2"
+"value1","value2"
+"value3","value4"

--- a/tests/methods/fixtures/auto-single-enclosure.csv
+++ b/tests/methods/fixtures/auto-single-enclosure.csv
@@ -1,0 +1,3 @@
+'column1','column2'
+'value1','value2'
+'value3','value4'


### PR DESCRIPTION
When calling `auto()` method for detecting delimiter parsing may not work correctly if we use enclosure different from double quote.
Here's example
test1.txt:

```
"column1","column2"
"value1","value2"
"value3","value4"
```

test2.txt:

```
'column1','column2'
'value1','value2'
'value3','value4'
```

test.php:

``` php
<?php
require_once 'parsecsv.lib.php';

$csv1 = new parseCSV();
$csv1->auto('test1.txt', true, null, null, '"');
print_r($csv1->data);

$csv2 = new parseCsv();
$csv2->auto('test2.txt', true, null, null, "'");
print_r($csv2->data);
```

Result is:

```
Array
(
    [0] => Array
        (
            [column1] => value1
            [column2] => value2
        )

    [1] => Array
        (
            [column1] => value3
            [column2] => value4
        )

)
Array
(
    [0] => Array
        (
            ['column1'] => 'value1'
            ['column2'] => 'value2'
        )

    [1] => Array
        (
            ['column1'] => 'value3'
            ['column2'] => 'value4'
        )

)
```
