### PR TITLE
Do not force filename if not set explicitly

### DIFF
--- a/parsecsv.lib.php
+++ b/parsecsv.lib.php
@@ -448,17 +448,14 @@ class parseCSV {
      * Generate a CSV based string for output.
      *
      * @access public
-     * @param  [string] $filename  If specified, headers and data will be output directly to browser as a downloable file
+     * @param  [string] $filename  If specified, headers and data will be output directly to browser as a downloadable file
      * @param  [array]  $data      2D array with data
      * @param  [array]  $fields    Field names
      * @param  [type]   $delimiter delimiter used to separate data
      *
-     * @return [string]
+     * @return [string] the resulting CSV string
      */
     public function output($filename = null, $data = array(), $fields = array(), $delimiter = null) {
-        if (empty($filename)) {
-            $filename = $this->output_filename;
-        }
 
         if ($delimiter === null) {
             $delimiter = $this->output_delimiter;


### PR DESCRIPTION
    Per docblock, the function output() is supposed to output to browser only if a filename is passed into it.
    If not, it should return the CSV as a string, not auto-set filename.

(Based on https://github.com/parsecsv/parsecsv-for-php/issues/87 )