### PR TITLE
Added support for return the correct data type

### DIFF
--- a/parsecsv.lib.php
+++ b/parsecsv.lib.php
@@ -733,7 +733,10 @@ class parseCSV {
                 // end of field/row/csv
             } elseif (($ch === $this->delimiter || $ch == "\n" || $ch == "\r" || $ch === false) && !$enclosed) {
                 $key = (!empty($head[$col])) ? $head[$col] : $col;
-                $row[$key] = ($was_enclosed) ? $current : trim($current);
+                $row[$key] = ($was_enclosed) ? $current : (float) trim($current) ;
+                if ( is_float($row[$key]) ) {
+                    $row[$key] = ((int) $row[$key] == (float) $row[$key]) ? (int) $row[$key] : $row[$key];
+                }
                 $current = '';
                 $was_enclosed = false;
                 $col++;


### PR DESCRIPTION
Actually is all returned like string, included when is not enclosed. With this change adds support to return int or float type.

Maybe breaks SQL-like conditions or some other functionallity.