### PR TITLE
refactor / improve construct and parse method

### DIFF
--- a/parsecsv.lib.php
+++ b/parsecsv.lib.php
@@ -20,4 +20,28 @@ require __DIR__ . '/vendor/autoload.php';
 // examples to find the up-to-date way of using this repo.
 class parseCSV extends ParseCsv\Csv {
 
+    /**
+     * @inheritdoc
+     */
+    public function __construct($input = null, $offset = null, $limit = null, $conditions = null, $keep_file_data = null) {
+        parent::__construct($input, [
+            'offset' => $offset,
+            'limit' => $limit,
+            'conditions' => $conditions,
+            'keep_file_data' => $keep_file_data,
+        ]);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function parse($input = null, $offset = null, $limit = null, $conditions = null) {
+        $this->init([
+            'offset' => $offset,
+            'limit' => $limit,
+            'conditions' => $conditions,
+        ]);
+
+        return $this->parse($input);
+    }
 }

--- a/src/Csv.php
+++ b/src/Csv.php
@@ -1,9 +1,10 @@
 <?php
 namespace ParseCsv;
 
+use ParseCsv\base\Object;
 use ParseCsv\extensions\DatatypeTrait;
 
-class Csv {
+class Csv extends Object {
 
     /*
     Class: parseCSV v0.4.3 beta
@@ -337,22 +338,9 @@ class Csv {
      * @param  string|null  $conditions     Basic SQL-like conditions for row matching
      * @param  null|true    $keep_file_data Keep raw file data in memory after successful parsing (useful for debugging)
      */
-    public function __construct($input = null, $offset = null, $limit = null, $conditions = null, $keep_file_data = null) {
-        if (!is_null($offset)) {
-            $this->offset = $offset;
-        }
+    public function __construct($input, $config = []) {
 
-        if (!is_null($limit)) {
-            $this->limit = $limit;
-        }
-
-        if (!is_null($conditions)) {
-            $this->conditions = $conditions;
-        }
-
-        if (!is_null($keep_file_data)) {
-            $this->keep_file_data = $keep_file_data;
-        }
+        parent::__construct($config);
 
         if (!empty($input)) {
             $this->parse($input);
@@ -368,43 +356,31 @@ class Csv {
      * Parse a CSV file or string
      *
      * @param  string|null $input      The CSV string or a direct filepath
-     * @param  integer     $offset     Number of rows to ignore from the beginning of  the data
-     * @param  integer     $limit      Limits the number of returned rows to specified amount
-     * @param  string      $conditions Basic SQL-like conditions for row matching
      *
      * @return bool True on success
      */
-    public function parse($input = null, $offset = null, $limit = null, $conditions = null) {
+    public function parse($input = null) {
         if (is_null($input)) {
             $input = $this->file;
         }
 
-        if (!empty($input)) {
-            if (!is_null($offset)) {
-                $this->offset = $offset;
-            }
-
-            if (!is_null($limit)) {
-                $this->limit = $limit;
-            }
-
-            if (!is_null($conditions)) {
-                $this->conditions = $conditions;
-            }
-
-            if (strlen($input) <= PHP_MAXPATHLEN && is_readable($input)) {
-                $this->data = $this->parse_file($input);
-            } else {
-                $this->file_data = &$input;
-                $this->data = $this->parse_string();
-            }
-
-            if ($this->data === false) {
-                return false;
-            }
+        if (empty($input)){
+            // todo: true is confusing
+            return true;
         }
 
-        return true;
+        if (strlen($input) <= PHP_MAXPATHLEN && is_readable($input)) {
+            $this->data = $this->parse_file($input);
+        }
+        else {
+            $this->file_data = &$input;
+            $this->data = $this->parse_string();
+        }
+
+        if ($this->data === false) {
+            return false;
+        }
+
     }
 
     /**

--- a/src/base/Object.php
+++ b/src/base/Object.php
@@ -15,10 +15,7 @@ class Object {
      */
     public function __construct($config = [])
     {
-        if (!empty($config)) {
-            self::configure($this, $config);
-        }
-        $this->init();
+        $this->init($config);
     }
 
     /**
@@ -26,8 +23,11 @@ class Object {
      * This method is invoked at the end of the constructor after the object is initialized with the
      * given configuration.
      */
-    public function init()
+    public function init($config = [])
     {
+        if (!empty($config)) {
+            self::configure($this, $config);
+        }
     }
 
     /**

--- a/src/base/Object.php
+++ b/src/base/Object.php
@@ -1,0 +1,52 @@
+<?php
+namespace ParseCsv\base;
+
+
+class Object {
+    /**
+     * Constructor.
+     *
+     * - Initializes the object with the given configuration `$config`.
+     * - Call init().
+     *
+     * If this method is overridden in a child class, it is recommended that
+     *
+     * @param array $config name-value pairs that will be used to initialize the object properties
+     */
+    public function __construct($config = [])
+    {
+        if (!empty($config)) {
+            self::configure($this, $config);
+        }
+        $this->init();
+    }
+
+    /**
+     * Initializes the object.
+     * This method is invoked at the end of the constructor after the object is initialized with the
+     * given configuration.
+     */
+    public function init()
+    {
+    }
+
+    /**
+     * Configures an object with the initial property values.
+     * @param object $object the object to be configured
+     * @param array $properties the property initial values given in terms of name-value pairs.
+     * @return object the object itself
+     */
+    public static function configure($object, $properties)
+    {
+        $objectClass = get_class($object);
+        foreach ($properties as $name => $value) {
+            if (property_exists($objectClass, $name)) {
+                $object->$name = $value;
+            } else {
+                throw new \Exception('Unknown property: ' . $name);
+            }
+        }
+
+        return $object;
+    }
+}

--- a/src/extensions/DatatypeTrait.php
+++ b/src/extensions/DatatypeTrait.php
@@ -25,13 +25,13 @@ trait DatatypeTrait {
      */
     private function getMostFrequentDatatypeForColumn($datatypes) {
         // remove 'false' from array (can happen if CSV cell is empty)
-        $types_filtered = array_filter($datatypes);
+        $typesFiltered = array_filter($datatypes);
 
-        if (empty($types_filtered)) {
+        if (empty($typesFiltered)) {
             return false;
         }
 
-        $typesFreq = array_count_values($types_filtered);
+        $typesFreq = array_count_values($typesFiltered);
         arsort($typesFreq);
         reset($typesFreq);
 

--- a/tests/methods/ConstructTest.php
+++ b/tests/methods/ConstructTest.php
@@ -37,37 +37,44 @@ class ConstructTest extends TestCase
         $this->csv = null;
     }
 
+    public function testWrongConfig() {
+        $offset = 10;
+        $this->csv = new Csv(null, ['blub' => $offset]);
+        // todo
+        //$this->expectException();
+    }
+
     public function test_offset_param() {
         $offset = 10;
-        $this->csv = new Csv(null, $offset);
+        $this->csv = new Csv(null, ['offset' => $offset]);
         $this->assertTrue(is_numeric($this->csv->offset));
         $this->assertEquals($offset, $this->csv->offset);
     }
 
     public function test_limit_param() {
         $limit = 10;
-        $this->csv = new Csv(null, null, $limit);
+        $this->csv = new Csv(null, ['limit' => $limit]);
         $this->assertTrue(is_numeric($this->csv->limit));
         $this->assertEquals($limit, $this->csv->limit);
     }
 
     public function test_conditions_param() {
         $conditions = 'some column NOT value';
-        $this->csv = new Csv(null, null, null, $conditions);
+        $this->csv = new Csv(null, ['conditions' => $conditions]);
         $this->assertTrue(is_string($this->csv->conditions));
         $this->assertEquals($conditions, $this->csv->conditions);
     }
 
     public function test_keep_file_data_param() {
         $keep = true;
-        $this->csv = new Csv(null, null, null, null, $keep);
+        $this->csv = new Csv(null, ['keep_file_data' => $keep]);
         $this->assertTrue(is_bool($this->csv->keep_file_data));
         $this->assertEquals($keep, $this->csv->keep_file_data);
     }
 
     public function test_input_param() {
         $csv = "col1,col2,col3\r\nval1,val2,val3\r\nval1A,val2A,val3A\r\n";
-        $this->csv = new Csv($csv, null, null, null, true);
+        $this->csv = new Csv($csv, ['keep_file_data'=> true]);
         $this->assertTrue(is_string($this->csv->file_data));
         $this->assertEquals($csv, $this->csv->file_data);
     }


### PR DESCRIPTION
This pull request is WIP. Feel free to close it because it needs another way of calling construction and parse method. 

I was confused by the duplications of setting properties in both methods. Another solution than the one I introduce here is to call constructor in the parse method but then the parse method could also be static.

Sorry, if I miss basics. I'm very interested in your feedbacks.