### PR TITLE
output(): Use better mime type for \t separator.

### DIFF
--- a/src/Csv.php
+++ b/src/Csv.php
@@ -455,7 +455,10 @@ class Csv {
         $flat_string = $this->unparse($data, $fields, null, null, $delimiter);
 
         if (!is_null($filename)) {
-            header('Content-type: application/csv');
+            $mime = $delimiter === "\t" ?
+                'text/tab-separated-values' :
+                'application/csv';
+            header('Content-type: ' . $mime);
             header('Content-Length: ' . strlen($flat_string));
             header('Cache-Control: no-cache, must-revalidate');
             header('Pragma: no-cache');


### PR DESCRIPTION
Fixes #79 

At some point in the future, 221c17521714b6ced694b35a409456257337d49c will be cherry-picked, too. I don't do it now to avoid conflicts.

@williamknauss @jimeh: I'll merge this small pull request on March 2 at the earliest unless you have any concerns. 