### PR TITLE
Version 1.0.0-rc.2: release candidate 2

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,12 +1,15 @@
-parseCSV 1.0.0 RC
+ParseCSV 1.0.0 RC
 -----------------------------------
 Date: unreleased
+
+- Renamed class from parseCSV to Csv and added name-
+  space "ParseCsv" for PSR compliance.
 
 - Added support for MS Excel's "sep=" to detect the
   delimiter (Issue #60).
 
 - Added support for mb_convert_encoding() instead of
-  iconv() - see issues #109
+  iconv() - see issue #109
 
 - A number of minor bug fixes - see GitHub issues
 

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,4 +1,4 @@
-ParseCSV 1.0.0 RC
+ParseCSV 1.0.0-rc.2
 -----------------------------------
 Date: unreleased
 

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,3 +1,18 @@
+parseCSV 1.0.0 RC
+-----------------------------------
+Date: unreleased
+
+- Added support for MS Excel's "sep=" to detect the
+  delimiter (Issue #60).
+
+- Added support for mb_convert_encoding() instead of
+  iconv() - see issues #109
+
+- A number of minor bug fixes - see GitHub issues
+
+-----------------------------------
+
+
 parseCSV 0.4.3 beta
 -----------------------------------
 Date: 1-July-2008
@@ -159,7 +174,7 @@ Date: 2-Jan-2007
 
 - Added auto() function to automatically detect
   delimiter character.
-  Useful for user upload incase delimiter is
+  Useful for user upload in case delimiter is
   comma (,), tab, or semi-colon (;). Some
   versions of MS Excel for Windows use
   semi-colons instead of commas when saving to
@@ -170,7 +185,7 @@ Date: 2-Jan-2007
   almost no matter what the delimiter is.
 
 - Generally updated some of the core workings
-  to increase performance, and offer better 
+  to increase performance, and offer better
   support for large (1MB and up) files.
 
 - Added code examples to header comment.

--- a/README.md
+++ b/README.md
@@ -13,15 +13,25 @@ and third-party support for handling CSV data in PHP.
 [csv]: http://en.wikipedia.org/wiki/Comma-separated_values
 
 ## Installation
-Installation is easy using Composer. Include the following in your composer.json
+
+Installation is easy using Composer. Just run the following on the
+command line:
 ```
-"parsecsv/php-parsecsv": "0.4.5"
+composer require parsecsv/php-parsecsv
 ```
 
-You may also manually include the parsecsv.lib.php file
+If you don't use a framework such as Drupal, Laravel, Symfony, Yii etc.,
+you may have to manually include Composer's autoloader file in your PHP
+script:
 ```php
-require_once 'parsecsv.lib.php';
+require_once __DIR__ . '/vendor/autoload.php';
 ```
+
+#### Without composer
+Not recommended, but technically possible: you can also clone the
+repository or extract the
+[ZIP](https://github.com/parsecsv/parsecsv-for-php/archive/master.zip).
+To use ParseCSV, you then have to add a `require 'parsecsv.lib.php';` line.
 
 ## Features
 
@@ -145,3 +155,5 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+[![Build Status](https://travis-ci.org/parsecsv/parsecsv-for-php.svg?branch=master)](https://travis-ci.org/parsecsv/parsecsv-for-php)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ParseCsv
 
-ParseCsv is an easy to use PHP class that reads and writes CSV data properly. It
+ParseCsv is an easy-to-use PHP class that reads and writes CSV data properly. It
 fully conforms to the specifications outlined on the on the
 [Wikipedia article][CSV] (and thus RFC 4180). It has many advanced features which help make your
 life easier when dealing with CSV data.

--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ To use ParseCSV, you then have to add a `require 'parsecsv.lib.php';` line.
 * Error detection for incorrectly formatted input. It attempts to be
   intelligent, but can not be trusted 100% due to the structure of CSV, and
   how different programs like Excel for example outputs CSV data.
-* Support for character encoding conversion using PHP's _iconv_ function
-  (requires PHP 5).
-* Supports PHP 5.4 and higher. It certainly works with PHP 7.2
-
+* Support for character encoding conversion using PHP's
+  `iconv()` and `mb_convert_encoding()` functions.
+* Supports PHP 5.4 and higher.
+  It certainly works with PHP 7.2 and all versions in between.
 
 ## Example Usage
 
@@ -105,7 +105,7 @@ $csv = new ParseCsv\Csv();
 $csv->save('data.csv', array(array('1986', 'Home', 'Nowhere', '')), true);
 ```
 
-**Convert 2D array to csv data and send headers to browser to treat output as
+**Convert 2D array to CSV data and send headers to browser to treat output as
 a file and download it**
 
 ```php

--- a/parsecsv.lib.php
+++ b/parsecsv.lib.php
@@ -1,20 +1,17 @@
 <?php
 
-// This file should not be used at all! It purely exists to reduce the
-// maintenance burden for existing code using this repo.
+// This file should not be used at all! Instead, please use Composer's autoload.
+// It purely exists to reduce the maintenance burden for existing code using
+// this repository.
 
 // Check if people used Composer to include this project in theirs
 if (!file_exists(__DIR__ . '/vendor/autoload.php')) {
-    die(
-        "Please run `composer dump-autoload` to build the autoloader.\n\n" .
-        "Actually, you should consider not including/requiring this file \n" .
-        "  " . __FILE__ . "\n" .
-        "Just run `composer require parsecsv/php-parsecsv` and look at the \n" .
-        "'examples' directory of this repository."
-    );
+    require __DIR__ . '/src/extensions/DatatypeTrait.php';
+    require __DIR__ . '/src/Csv.php';
+} else {
+    require __DIR__ . '/vendor/autoload.php';
 }
 
-require __DIR__ . '/vendor/autoload.php';
 
 // This wrapper class should not be used by new projects. Please look at the
 // examples to find the up-to-date way of using this repo.

--- a/src/Csv.php
+++ b/src/Csv.php
@@ -7,7 +7,7 @@ use ParseCsv\extensions\DatatypeTrait;
 class Csv {
 
     /*
-    Class: ParseCSV v1.0.0
+    Class: ParseCSV 1.0.0-rc.2
     https://github.com/parsecsv/parsecsv-for-php
 
     Fully conforms to the specifications lined out on Wikipedia:

--- a/src/Csv.php
+++ b/src/Csv.php
@@ -7,7 +7,7 @@ use ParseCsv\extensions\DatatypeTrait;
 class Csv {
 
     /*
-    Class: parseCSV v0.4.3 beta
+    Class: ParseCSV v1.0.0
     https://github.com/parsecsv/parsecsv-for-php
 
     Fully conforms to the specifications lined out on Wikipedia:
@@ -39,43 +39,7 @@ class Csv {
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
     THE SOFTWARE.
 
-
-    Code Examples
-    ----------------
-    # general usage
-    $csv = new parseCSV('data.csv');
-    print_r($csv->data);
-    ----------------
-    # tab delimited, and encoding conversion
-    $csv = new parseCSV();
-    $csv->encoding('UTF-16', 'UTF-8');
-    $csv->delimiter = "\t";
-    $csv->parse('data.tsv');
-    print_r($csv->data);
-    ----------------
-    # auto-detect delimiter character
-    $csv = new parseCSV();
-    $csv->auto('data.csv');
-    print_r($csv->data);
-    ----------------
-    # modify data in a csv file
-    $csv = new parseCSV();
-    $csv->sort_by = 'id';
-    $csv->parse('data.csv');
-    # "4" is the value of the "id" column of the CSV row
-    $csv->data[4] = array('firstname' => 'John', 'lastname' => 'Doe', 'email' => 'john@doe.com');
-    $csv->save();
-    ----------------
-    # add row/entry to end of CSV file
-    #  - only recommended when you know the exact structure of the file
-    $csv = new parseCSV();
-    $csv->save('data.csv', array(array('1986', 'Home', 'Nowhere', '')), true);
-    ----------------
-    # convert 2D array to csv data and send headers
-    # to browser to treat output as a file and download it
-    $csv = new parseCSV();
-    $csv->output('movies.csv', $array, array('field 1', 'field 2'), ',');
-    ----------------
+    For code examples, please read the files within the 'examples' dir.
      */
 
     /**

--- a/src/Csv.php
+++ b/src/Csv.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ParseCsv;
 
 use ParseCsv\extensions\DatatypeTrait;

--- a/tests/methods/ConstructTest.php
+++ b/tests/methods/ConstructTest.php
@@ -8,34 +8,9 @@ use PHPUnit\Framework\TestCase;
 class ConstructTest extends TestCase {
 
     /**
-     * CSV
-     * The Csv object
-     *
-     * @access protected
-     * @var    Csv
+     * @var Csv object
      */
     protected $csv = null;
-
-    /**
-     * Setup
-     * Setup our test environment objects
-     *
-     * @access public
-     */
-    public function setUp() {
-        //setup parse CSV
-        #$this->csv = new Csv();
-    }
-
-    /**
-     * Tear down
-     * Tear down our test environment objects
-     *
-     * @access public
-     */
-    public function tearDown() {
-        $this->csv = null;
-    }
 
     public function test_offset_param() {
         $offset = 10;

--- a/tests/methods/ConstructTest.php
+++ b/tests/methods/ConstructTest.php
@@ -62,5 +62,6 @@ class ConstructTest extends TestCase {
                 $this->assertContains('<td>', ob_get_clean());
             }
         }
+        chdir('..');
     }
 }

--- a/tests/methods/OldRequireTest.php
+++ b/tests/methods/OldRequireTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace ParseCsv\tests\methods;
+
+use PHPUnit\Framework\TestCase;
+
+class OldRequireTest extends TestCase {
+
+    protected function setUp() {
+        rename('vendor/autoload.php', '__autoload');
+    }
+
+    protected function tearDown() {
+        rename('__autoload', 'vendor/autoload.php');
+    }
+
+    /**
+     * @runInSeparateProcess because download.php uses header()
+     */
+    public function testOldLibWithoutComposer() {
+
+        file_put_contents('__eval.php', '<?php require "parsecsv.lib.php"; new \ParseCsv\Csv;');
+        exec("php __eval.php", $output, $return_var);
+        unlink('__eval.php');
+        $this->assertEquals($output, []);
+        $this->assertEquals(0, $return_var);
+    }
+}

--- a/tests/methods/ParseTest.php
+++ b/tests/methods/ParseTest.php
@@ -8,11 +8,7 @@ class ParseTest extends TestCase
 {
 
     /**
-     * CSV
-     * The CSV object
-     *
-     * @access protected
-     * @var Csv
+     * @var Csv object
      */
     protected $csv;
 


### PR DESCRIPTION
This pull request is a follow-up to #111. The aim is to officially release a 1.0.0 version very soon. Based on the fruitful discussion there, @susgo went ahead and created a namespace `ParseCsv`. For now, the only public class within that is `Csv`. These changes were already merged into the master in #114 . After this is in master we can easily provide several classes with traits (without copy-pasting code):
- ``Csv`` is the current class that does everything 
- ``Parser`` lacks the ability to save() and output()
- ``Builder`` takes a PHP array and continues from there.



In this pull request, you'll find: 
- Improved compatibility if no composer
- officially statement to be compatible with PHP 7

@williamknauss @jimeh, dear community: What do you think?

(In the surprising case this pull request doesn't yield any feedback, I'll go ahead and merge it on March 2 at the earliest)