### PR TITLE
New feature: get total row count

### DIFF
--- a/src/Csv.php
+++ b/src/Csv.php
@@ -547,7 +547,7 @@ class Csv {
      *
      * @return bool|int
      */
-    public function getTotalRowCount() {
+    public function getTotalDataRowCount() {
         if (empty($this->file_data)) {
             return false;
         }

--- a/src/Csv.php
+++ b/src/Csv.php
@@ -540,6 +540,41 @@ class Csv {
         return $this->delimiter;
     }
 
+    /**
+     * Get total number of rows in csv without parsing whole data.
+     *
+     * @return bool|int
+     */
+    public function getTotalRowCount(){
+        if (empty($this->file_data)){
+            return false;
+        }
+
+        $this->_detect_and_remove_sep_row_from_data($this->file_data);
+
+        $pattern = sprintf('/("[^%s]*")|[^%s]*/i',$this->enclosure, $this->enclosure);
+        preg_match_all($pattern,$this->file_data, $matches);
+
+        foreach ($matches[0] as $match){
+            if (empty($match) || !preg_match("/{$this->enclosure}/", $match)){
+                continue;
+            }
+
+            $replace = str_replace(["\r", "\n"], '', $match);
+            $this->file_data = str_replace($match, $replace, $this->file_data);
+        }
+
+        $headingRow = $this->heading ? 1 : 0;
+
+        $count = substr_count($this->file_data, "\r")
+            + substr_count($this->file_data, "\n")
+            - substr_count($this->file_data, "\r\n")
+            - $headingRow;
+
+
+        return $count;
+    }
+
     // ==============================================
     // ----- [ Core Functions ] ---------------------
     // ==============================================

--- a/src/Csv.php
+++ b/src/Csv.php
@@ -558,7 +558,7 @@ class Csv {
         preg_match_all($pattern, $this->file_data, $matches);
 
         foreach ($matches[0] as $match) {
-            if (empty($match) || !preg_match("/{$this->enclosure}/", $match)) {
+            if (empty($match) || (strpos($match, $this->enclosure) === false)) {
                 continue;
             }
 

--- a/src/Csv.php
+++ b/src/Csv.php
@@ -556,7 +556,7 @@ class Csv {
 
         $this->_detect_and_remove_sep_row_from_data($data);
 
-        $pattern = sprintf('/("[^%s]*")|[^%s]*/i', $this->enclosure, $this->enclosure);
+        $pattern = sprintf('/(%1$s[^%1$s]*%1$s)/i', $this->enclosure);
         preg_match_all($pattern, $data, $matches);
 
         foreach ($matches[0] as $match) {

--- a/src/Csv.php
+++ b/src/Csv.php
@@ -552,10 +552,12 @@ class Csv {
             return false;
         }
 
-        $this->_detect_and_remove_sep_row_from_data($this->file_data);
+        $data = $this->file_data;
+
+        $this->_detect_and_remove_sep_row_from_data($data);
 
         $pattern = sprintf('/("[^%s]*")|[^%s]*/i', $this->enclosure, $this->enclosure);
-        preg_match_all($pattern, $this->file_data, $matches);
+        preg_match_all($pattern, $data, $matches);
 
         foreach ($matches[0] as $match) {
             if (empty($match) || (strpos($match, $this->enclosure) === false)) {
@@ -563,14 +565,14 @@ class Csv {
             }
 
             $replace = str_replace(["\r", "\n"], '', $match);
-            $this->file_data = str_replace($match, $replace, $this->file_data);
+            $data = str_replace($match, $replace, $data);
         }
 
         $headingRow = $this->heading ? 1 : 0;
 
-        $count = substr_count($this->file_data, "\r")
-            + substr_count($this->file_data, "\n")
-            - substr_count($this->file_data, "\r\n")
+        $count = substr_count($data, "\r")
+            + substr_count($data, "\n")
+            - substr_count($data, "\r\n")
             - $headingRow;
 
 

--- a/src/Csv.php
+++ b/src/Csv.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ParseCsv;
 
 use ParseCsv\extensions\DatatypeTrait;
@@ -541,22 +542,23 @@ class Csv {
     }
 
     /**
-     * Get total number of rows in csv without parsing whole data.
+     * Get total number of data rows (exclusive heading line if present) in csv
+     * without parsing whole data.
      *
      * @return bool|int
      */
-    public function getTotalRowCount(){
-        if (empty($this->file_data)){
+    public function getTotalRowCount() {
+        if (empty($this->file_data)) {
             return false;
         }
 
         $this->_detect_and_remove_sep_row_from_data($this->file_data);
 
-        $pattern = sprintf('/("[^%s]*")|[^%s]*/i',$this->enclosure, $this->enclosure);
-        preg_match_all($pattern,$this->file_data, $matches);
+        $pattern = sprintf('/("[^%s]*")|[^%s]*/i', $this->enclosure, $this->enclosure);
+        preg_match_all($pattern, $this->file_data, $matches);
 
-        foreach ($matches[0] as $match){
-            if (empty($match) || !preg_match("/{$this->enclosure}/", $match)){
+        foreach ($matches[0] as $match) {
+            if (empty($match) || !preg_match("/{$this->enclosure}/", $match)) {
                 continue;
             }
 
@@ -950,12 +952,19 @@ class Csv {
      */
     protected function _validate_row_condition($row, $condition) {
         $operators = array(
-            '=', 'equals', 'is',
-            '!=', 'is not',
-            '<', 'is less than',
-            '>', 'is greater than',
-            '<=', 'is less than or equals',
-            '>=', 'is greater than or equals',
+            '=',
+            'equals',
+            'is',
+            '!=',
+            'is not',
+            '<',
+            'is less than',
+            '>',
+            'is greater than',
+            '<=',
+            'is less than or equals',
+            '>=',
+            'is greater than or equals',
             'contains',
             'does not contain',
         );

--- a/tests/methods/DataRowCountTest.php
+++ b/tests/methods/DataRowCountTest.php
@@ -63,4 +63,14 @@ class DataRowCountTest extends TestCase {
         $this->csv->load_data($sInput);
         $this->assertEquals(3, $this->csv->getTotalDataRowCount());
     }
+
+
+    public function testGetTotalRowCountSingleEnclosure() {
+        $this->csv->heading = false;
+        $this->csv->enclosure = "'";
+        $sInput = "86545235689,a\r\n34365587654,b\r\n13469874576,\'c\r\nd\'";
+        $this->csv->load_data($sInput);
+        $this->assertEquals(3, $this->csv->getTotalDataRowCount());
+    }
+
 }

--- a/tests/methods/DataRowCountTest.php
+++ b/tests/methods/DataRowCountTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace ParseCsv\tests\methods;
+
+use ParseCsv\Csv;
+use PHPUnit\Framework\TestCase;
+
+
+class DataRowCountTest extends TestCase {
+
+    /**
+     * CSV
+     * The CSV object
+     *
+     * @access protected
+     * @var Csv
+     */
+    protected $csv;
+
+    /**
+     * Setup
+     * Setup our test environment objects
+     *
+     * @access public
+     */
+    public function setUp() {
+        $this->csv = new Csv();
+    }
+
+    public function countRowsProvider() {
+        return [
+            'auto-double-enclosure' => [
+                'auto-double-enclosure.csv',
+                2,
+            ],
+            'auto-single-enclosure' => [
+                'auto-single-enclosure.csv',
+                2,
+            ],
+            'UTF-8_sep_row' => [
+                'datatype.csv',
+                3,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider countRowsProvider
+     *
+     * @param string $file
+     * @param int    $expectedRows
+     */
+    public function testGetTotalRowCountFromFile($file, $expectedRows) {
+        $this->csv->heading = true;
+        $this->csv->load_data(__DIR__ . '/fixtures/' . $file);
+        $this->assertEquals($expectedRows, $this->csv->getTotalDataRowCount());
+    }
+
+    public function testGetTotalRowCountMissingEndingLineBreak() {
+        $this->csv->heading = false;
+        $this->csv->enclosure = '"';
+        $sInput = "86545235689,a\r\n34365587654,b\r\n13469874576,\"c\r\nd\"";
+        $this->csv->load_data($sInput);
+        $this->assertEquals(3, $this->csv->getTotalDataRowCount());
+    }
+}

--- a/tests/methods/ParseTest.php
+++ b/tests/methods/ParseTest.php
@@ -198,4 +198,41 @@ class ParseTest extends TestCase
         $this->assertArrayHasKey('column1', $csv->data[0], 'Data parsed incorrectly with enclosure ' . $enclosure);
         $this->assertEquals('value1', $csv->data[0]['column1'], 'Data parsed incorrectly with enclosure ' . $enclosure);
     }
+
+    public function countRowsProvider(){
+        return [
+            'auto-double-enclosure' => [
+                'auto-double-enclosure.csv',
+                2
+            ],
+            'auto-single-enclosure' => [
+                'auto-single-enclosure.csv',
+                2
+            ],
+            'UTF-8_sep_row' => [
+                'datatype.csv',
+                3
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider countRowsProvider
+     *
+     * @param string $file
+     * @param int $expectedRows
+     */
+    public function testGetTotalRowCountFromFile($file, $expectedRows){
+        $this->csv->heading = true;
+        $this->csv->load_data(__DIR__ . '/fixtures/' . $file);
+        $this->assertEquals($expectedRows, $this->csv->getTotalRowCount());
+    }
+
+    public function testGetTotalRowCountMissingEndingLineBreak(){
+        $this->csv->heading = false;
+        $this->csv->enclosure = '"';
+        $sInput = "86545235689,a\r\n34365587654,b\r\n13469874576,\"c\r\nd\"";
+        $this->csv->load_data($sInput);
+        $this->assertEquals(3, $this->csv->getTotalRowCount());
+    }
 }

--- a/tests/methods/ParseTest.php
+++ b/tests/methods/ParseTest.php
@@ -225,7 +225,7 @@ class ParseTest extends TestCase
     public function testGetTotalRowCountFromFile($file, $expectedRows){
         $this->csv->heading = true;
         $this->csv->load_data(__DIR__ . '/fixtures/' . $file);
-        $this->assertEquals($expectedRows, $this->csv->getTotalRowCount());
+        $this->assertEquals($expectedRows, $this->csv->getTotalDataRowCount());
     }
 
     public function testGetTotalRowCountMissingEndingLineBreak(){
@@ -233,6 +233,6 @@ class ParseTest extends TestCase
         $this->csv->enclosure = '"';
         $sInput = "86545235689,a\r\n34365587654,b\r\n13469874576,\"c\r\nd\"";
         $this->csv->load_data($sInput);
-        $this->assertEquals(3, $this->csv->getTotalRowCount());
+        $this->assertEquals(3, $this->csv->getTotalDataRowCount());
     }
 }

--- a/tests/methods/ParseTest.php
+++ b/tests/methods/ParseTest.php
@@ -198,41 +198,4 @@ class ParseTest extends TestCase
         $this->assertArrayHasKey('column1', $csv->data[0], 'Data parsed incorrectly with enclosure ' . $enclosure);
         $this->assertEquals('value1', $csv->data[0]['column1'], 'Data parsed incorrectly with enclosure ' . $enclosure);
     }
-
-    public function countRowsProvider(){
-        return [
-            'auto-double-enclosure' => [
-                'auto-double-enclosure.csv',
-                2
-            ],
-            'auto-single-enclosure' => [
-                'auto-single-enclosure.csv',
-                2
-            ],
-            'UTF-8_sep_row' => [
-                'datatype.csv',
-                3
-            ]
-        ];
-    }
-
-    /**
-     * @dataProvider countRowsProvider
-     *
-     * @param string $file
-     * @param int $expectedRows
-     */
-    public function testGetTotalRowCountFromFile($file, $expectedRows){
-        $this->csv->heading = true;
-        $this->csv->load_data(__DIR__ . '/fixtures/' . $file);
-        $this->assertEquals($expectedRows, $this->csv->getTotalDataRowCount());
-    }
-
-    public function testGetTotalRowCountMissingEndingLineBreak(){
-        $this->csv->heading = false;
-        $this->csv->enclosure = '"';
-        $sInput = "86545235689,a\r\n34365587654,b\r\n13469874576,\"c\r\nd\"";
-        $this->csv->load_data($sInput);
-        $this->assertEquals(3, $this->csv->getTotalDataRowCount());
-    }
 }


### PR DESCRIPTION
implements new function for getting total number of rows from csv without parsing the data

**Motivation**
When reading or importing large files we do not want to process the whole file all at once. Instead we would like to read it in smaller steps and we would like to give the customers feedback about the progress. Therefore we need the total number of datasets in the file at the beginning of the process.

Please feel free to close this request if the feature is not needed for others. Also may be there is a better way to implement that or it is already covered by the existing code and I missed it. 