### PR TITLE
New feature: Auto detect if file has heading

### DIFF
--- a/src/extensions/DatatypeTrait.php
+++ b/src/extensions/DatatypeTrait.php
@@ -2,6 +2,8 @@
 
 namespace ParseCsv\extensions;
 
+use ParseCsv\enums\DatatypeEnum;
+
 trait DatatypeTrait {
 
     /**
@@ -47,7 +49,7 @@ trait DatatypeTrait {
      *
      * @access public
      *
-     * @uses   getDatatypeFromString
+     * @uses   DatatypeEnum::getValidTypeFromSample
      *
      * @return array|bool
      */
@@ -70,5 +72,41 @@ trait DatatypeTrait {
         $this->data_types = $result;
 
         return !empty($this->data_types) ? $this->data_types : [];
+    }
+
+    /**
+     * Check data type of titles / first row for auto detecting if this could be
+     * a heading line.
+     *
+     * Requires PHP >= 5.5
+     *
+     * @access public
+     *
+     * @uses   DatatypeEnum::getValidTypeFromSample
+     *
+     * @return bool
+     */
+    public function autoDetectFileHasHeading(){
+        if (empty($this->data)){
+            throw new \UnexpectedValueException('No data set yet.');
+        }
+
+        if ($this->heading){
+            $firstRow = $this->titles;
+        } else {
+            $firstRow = $this->data[0];
+        }
+
+        if (empty(array_filter($firstRow))){
+            return false;
+        }
+
+        $firstRowDatatype = array_map('ParseCsv\enums\DatatypeEnum::getValidTypeFromSample', $firstRow);
+
+        if ($this->getMostFrequentDatatypeForColumn($firstRowDatatype) !== DatatypeEnum::TYPE_STRING){
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/extensions/DatatypeTrait.php
+++ b/src/extensions/DatatypeTrait.php
@@ -64,7 +64,7 @@ trait DatatypeTrait {
         $result = [];
         foreach ($this->titles as $cName) {
             $column = array_column($this->data, $cName);
-            $cDatatypes = array_map('ParseCsv\enums\DatatypeEnum::getValidTypeFromSample', $column);
+            $cDatatypes = array_map(DatatypeEnum::class . '::getValidTypeFromSample', $column);
 
             $result[$cName] = $this->getMostFrequentDatatypeForColumn($cDatatypes);
         }
@@ -102,7 +102,7 @@ trait DatatypeTrait {
             return false;
         }
 
-        $firstRowDatatype = array_map('ParseCsv\enums\DatatypeEnum::getValidTypeFromSample', $firstRow);
+        $firstRowDatatype = array_map(DatatypeEnum::class . '::getValidTypeFromSample', $firstRow);
 
         if ($this->getMostFrequentDatatypeForColumn($firstRowDatatype) !== DatatypeEnum::TYPE_STRING){
             return false;

--- a/src/extensions/DatatypeTrait.php
+++ b/src/extensions/DatatypeTrait.php
@@ -97,7 +97,8 @@ trait DatatypeTrait {
             $firstRow = $this->data[0];
         }
 
-        if (empty(array_filter($firstRow))){
+        $firstRow = array_filter($firstRow);
+        if (empty($firstRow)){
             return false;
         }
 

--- a/tests/methods/ParseTest.php
+++ b/tests/methods/ParseTest.php
@@ -157,6 +157,26 @@ class ParseTest extends TestCase
         $this->assertEquals($expected, $this->csv->data_types);
     }
 
+    public function testAutoDetectFileHasHeading(){
+        $this->csv->auto(__DIR__ . '/fixtures/datatype.csv');
+        $this->assertTrue($this->csv->autoDetectFileHasHeading());
+
+        $this->csv->heading = false;
+        $this->csv->auto(__DIR__ . '/fixtures/datatype.csv');
+        $this->assertTrue($this->csv->autoDetectFileHasHeading());
+
+        $this->csv->heading = false;
+        $sInput = "86545235689\r\n34365587654\r\n13469874576";
+        $this->csv->auto($sInput);
+        $this->assertFalse($this->csv->autoDetectFileHasHeading());
+
+        $this->csv->heading = true;
+        $sInput = "86545235689\r\n34365587654\r\n13469874576";
+        $this->csv->auto($sInput);
+        $this->assertFalse($this->csv->autoDetectFileHasHeading());
+
+    }
+
     protected function _get_magazines_data() {
         return [
             [

--- a/tests/methods/ParseTest.php
+++ b/tests/methods/ParseTest.php
@@ -161,6 +161,12 @@ class ParseTest extends TestCase
      * @depends testSepRowAutoDetection
      */
     public function testAutoDetectFileHasHeading(){
+        if (!function_exists('array_column')) {
+            // getDatatypes requires array_column, but that
+            // function is only available in PHP >= 5.5
+            return;
+        }
+        
         $this->csv->auto(__DIR__ . '/fixtures/datatype.csv');
         $this->assertTrue($this->csv->autoDetectFileHasHeading());
 

--- a/tests/methods/ParseTest.php
+++ b/tests/methods/ParseTest.php
@@ -157,6 +157,9 @@ class ParseTest extends TestCase
         $this->assertEquals($expected, $this->csv->data_types);
     }
 
+    /**
+     * @depends testSepRowAutoDetection
+     */
     public function testAutoDetectFileHasHeading(){
         $this->csv->auto(__DIR__ . '/fixtures/datatype.csv');
         $this->assertTrue($this->csv->autoDetectFileHasHeading());


### PR DESCRIPTION
implements new function for auto detection of heading property

**Motivation**
We use a data preview of 5 - 10 lines where customers get the possibility to change the auto detected delimiter and can check if csv file has heading or not (this is necessary for further data processing steps) For the preview we use the limitation functionality so that we not have to process whole file. For the preselection on preview step I would like to auto detect if the file has a heading. (Customer can change it, if software detection is wrong)

**Solution**
Currently the function only checks if the most frequently data type of the heading / first row is string.
The function doesn't change the public properties or parses data newly. Should we do that here? 
Also I could implement a second mode (don't know how to name it) were the data type of each cell in the first row would be compared with the data type getting from the rest of the columns. That should be different in minimum one column to get some more evidence that first row contains headings. What do you think?

Please feel free to close this request if the feature is not needed for others. Also may be there is a better way to implement that or it is already covered by the existing code and I missed it.