### PR TITLE
Issue 42 heading and offset

### DIFF
--- a/src/Csv.php
+++ b/src/Csv.php
@@ -987,7 +987,8 @@ class Csv {
         return
             $this->sort_by !== null ||
             $this->offset === null ||
-            $current_row >= $this->offset;
+            $current_row >= $this->offset ||
+            ($this->heading && $current_row == 0);
     }
 
     /**

--- a/tests/methods/ParseTest.php
+++ b/tests/methods/ParseTest.php
@@ -157,6 +157,31 @@ class ParseTest extends TestCase
         $this->assertEquals($expected, $this->csv->data_types);
     }
 
+
+    public function testDataArrayKeysWhenSettingOffsetWithHeading() {
+        $this->csv->offset = 2;
+        $this->csv->auto(__DIR__ . '/fixtures/datatype.csv');
+        $expected = [
+            'title',
+            'isbn',
+            'publishedAt',
+            'published',
+            'count',
+            'price'
+        ];
+
+        $this->assertEquals($expected, array_keys($this->csv->data[0]));
+    }
+
+    public function testDataArrayKeysWhenSettingOffsetWithoutHeading() {
+        $this->csv->heading = false;
+        $this->csv->offset = 2;
+        $this->csv->auto(__DIR__ . '/fixtures/datatype.csv');
+        $expected = range(0,5, 1);
+        
+        $this->assertEquals($expected, array_keys($this->csv->data[0]));
+    }
+
     protected function _get_magazines_data() {
         return [
             [


### PR DESCRIPTION
This is **work in progress** at the moment.
At the moment I have only added two tests: test with heading fails like described in #42 

````
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
-    0 => 'title'
-    1 => 'isbn'
-    2 => 'publishedAt'
-    3 => 'published'
-    4 => 'count'
-    5 => 'price'
+    0 => 'The Wine Connoisseurs'
+    1 => '2547-8548-2541'
+    2 => '12.12.2011'
+    3 => 'TRUE'
+    4 => 4
+    5 => '20.33'
````