### PR TITLE
Fix #41: output order and subset

### DIFF
--- a/src/Csv.php
+++ b/src/Csv.php
@@ -777,8 +777,15 @@ class Csv {
         $entry = array();
 
         // create heading
+        $fieldOrder = $this->_validate_fields_for_unparse($fields);
+        if (!$fieldOrder && !empty($data)){
+            $column_count = count($data[0]) - 1;
+            $columns = range(0, $column_count, 1);
+            $fieldOrder = array_combine($columns, $columns);
+        }
+
         if ($this->heading && !$append && !empty($fields)) {
-            foreach ($fields as $key => $column_name) {
+            foreach ($fieldOrder as $column_name) {
                 $entry[] = $this->_enclose_value($column_name, $delimiter);
             }
 
@@ -788,7 +795,8 @@ class Csv {
 
         // create data
         foreach ($data as $key => $row) {
-            foreach ($row as $cell_value) {
+            foreach (array_keys($fieldOrder) as $index){
+                $cell_value = $row[$index];
                 $entry[] = $this->_enclose_value($cell_value, $delimiter);
             }
 
@@ -801,6 +809,36 @@ class Csv {
         }
 
         return $string;
+    }
+
+    private function _validate_fields_for_unparse($fields){
+        if (empty($fields)){
+            return [];
+        }
+
+        // both are identical, also in ordering
+        if (array_values($fields) === array_values($this->titles)){
+            return array_combine($fields, $fields);
+        }
+
+        // if renaming given by: $oldName => $newName (maybe with reorder and / or subset):
+        // todo: this will only work if titles are unique
+        $fieldOrder = array_intersect(array_flip($fields), $this->titles);
+        if (!empty($fieldOrder)) {
+            return array_flip($fieldOrder);
+        }
+
+        $fieldOrder = array_intersect($fields, $this->titles);
+        if (!empty($fieldOrder)) {
+            return array_combine($fieldOrder, $fieldOrder);
+        }
+
+        // original titles are not given in fields. that is okay if count is okay.
+        if (count($fields) != count($this->titles)) {
+            throw new \UnexpectedValueException('The specified fields do not match any titles and do not match column count.');
+        }
+
+        return array_combine($this->titles, $fields);
     }
 
     /**

--- a/src/Csv.php
+++ b/src/Csv.php
@@ -778,9 +778,9 @@ class Csv {
 
         // create heading
         $fieldOrder = $this->_validate_fields_for_unparse($fields);
-        if (!$fieldOrder && !empty($data)){
-            $column_count = count($data[0]) - 1;
-            $columns = range(0, $column_count, 1);
+        if (!$fieldOrder && !empty($data)) {
+            $column_count = count($data[0]);
+            $columns = range(0, $column_count - 1, 1);
             $fieldOrder = array_combine($columns, $columns);
         }
 

--- a/tests/methods/UnparseTest.php
+++ b/tests/methods/UnparseTest.php
@@ -1,0 +1,54 @@
+<?php
+namespace ParseCsv\tests\methods;
+
+use ParseCsv\Csv;
+use PHPUnit\Framework\TestCase;
+
+
+class UnparseTest extends Testcase {
+    /** @var Csv */
+    private $csv;
+
+    /**
+     * Setup our test environment objects; will be called before each test.
+     */
+    public function setUp() {
+        $this->csv = new Csv();
+        $this->csv->auto(__DIR__ . '/fixtures/auto-double-enclosure.csv');
+    }
+
+    public function testUnparseDefault() {
+        $expected = "column1,column2\rvalue1,value2\rvalue3,value4\r";
+        $this->unparseAndCompare($expected);
+    }
+
+    public function testUnparseRenameFields() {
+        $expected = "C1,C2\rvalue1,value2\rvalue3,value4\r";
+        $this->unparseAndCompare($expected, array("C1", "C2"));
+    }
+
+    public function testReorderFields() {
+        $expected = "column2,column1\rvalue2,value1\rvalue4,value3\r";
+        $this->unparseAndCompare($expected, array("column2", "column1"));
+    }
+
+    public function testSubsetFields() {
+        $expected = "column1\rvalue1\rvalue3\r";
+        $this->unparseAndCompare($expected, array("column1"));
+    }
+
+    public function testReorderAndRenameFields() {
+        $fields = array(
+            'column2' => 'C2',
+            'column1' => 'C1',
+        );
+        $expected = "C2,C1\rvalue2,value1\rvalue4,value3\r";
+        $this->unparseAndCompare($expected, $fields);
+    }
+
+    private function unparseAndCompare($expected, $fields = array()) {
+        $str = $this->csv->unparse($this->csv->data, $fields);
+        $this->assertEquals($expected, $str);
+    }
+
+}

--- a/tests/methods/UnparseTest.php
+++ b/tests/methods/UnparseTest.php
@@ -22,6 +22,14 @@ class UnparseTest extends Testcase {
         $this->unparseAndCompare($expected);
     }
 
+    public function testUnparseDefaultWithoutHeading(){
+        $this->csv->heading = false;
+        $this->csv->auto(__DIR__ . '/fixtures/auto-double-enclosure.csv');
+        $expected = "column1,column2\rvalue1,value2\rvalue3,value4\r";
+        $this->unparseAndCompare($expected);
+
+    }
+
     public function testUnparseRenameFields() {
         $expected = "C1,C2\rvalue1,value2\rvalue3,value4\r";
         $this->unparseAndCompare($expected, array("C1", "C2"));


### PR DESCRIPTION
~~This is currently **work in progress**.~~

At the moment this request only implements tests of features which should be done for solving the comments on #41. In my opinion the following things should be work:
* [x] If no `fields` are given take the `title` property. Works.
* [x] If the given `fields` define same number of strings like `titles` attribute, but the names are different (the strings differ) from the `titles` property then the fields should be renamed. Works as default.
* [x] If the given `fields` are an subset of the `titles` property, only subset should be unparsed.
* [x] If the given `fields` are a reorder of the `titles` property, data should be reordered, too, on unparsing
* [x] Allow renaming and reordering by using array keys in `fields`

This request is ready, when all tests are green. 

Please feel free to close this pull request if the feature is not needed anymore or I miss something.