### PR TITLE
Improved OldRequireTest: explanation and new test added

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -12,7 +12,7 @@ Date: 3-March-2018
   guesses the type of each column.
 
 - MIME: output() sends correct MIME type to browser
-  if the separator is a tab tab (Issue #79).
+  if the separator is a tab char (Issue #79).
 
 - Added support for mb_convert_encoding() instead of
   iconv() - see issue #109.

--- a/tests/methods/OldRequireTest.php
+++ b/tests/methods/OldRequireTest.php
@@ -4,6 +4,11 @@ namespace ParseCsv\tests\methods;
 
 use PHPUnit\Framework\TestCase;
 
+/**
+ * This test checks for backwards compatibility: Does it work to
+ *   - require the old "parsecsv.lib.php" instead of composer autoloading?
+ *   - use the old class name "parseCSV"?
+ */
 class OldRequireTest extends TestCase {
 
     protected function setUp() {
@@ -15,11 +20,23 @@ class OldRequireTest extends TestCase {
     }
 
     /**
-     * @runInSeparateProcess because download.php uses header()
+     * @runInSeparateProcess so that disabled autoloading has an effect
      */
     public function testOldLibWithoutComposer() {
 
         file_put_contents('__eval.php', '<?php require "parsecsv.lib.php"; new \ParseCsv\Csv;');
+        exec("php __eval.php", $output, $return_var);
+        unlink('__eval.php');
+        $this->assertEquals($output, []);
+        $this->assertEquals(0, $return_var);
+    }
+
+    /**
+     * @runInSeparateProcess so that disabled autoloading has an effect
+     */
+    public function testOldLibWithOldClassName() {
+
+        file_put_contents('__eval.php', '<?php require "parsecsv.lib.php"; new parseCSV;');
         exec("php __eval.php", $output, $return_var);
         unlink('__eval.php');
         $this->assertEquals($output, []);


### PR DESCRIPTION
The test name sounded like the test is obsolete - but it's here to stay, especially now that we have a new release.

@williamknauss @jimeh I'll merge this on March 10 unless you voice a need for improvements.