### PR TITLE
Dropping PHP 5.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ php:
   - 7.0
   - 5.6
   - 5.5
-  - 5.4
 
 script:
   - phpunit --version

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -5,6 +5,8 @@ Date: unreleased
 - New function getTotalDataRowCount() - useful if
   $limit is set - see pull request #122.
 
+- Dropped support for PHP 5.4
+
 -----------------------------------
 
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ and third-party support for handling CSV data in PHP.
   how different programs like Excel for example outputs CSV data.
 * Support for character encoding conversion using PHP's
   `iconv()` and `mb_convert_encoding()` functions.
-* Supports PHP 5.4 and higher.
+* Supports PHP 5.5 and higher.
   It certainly works with PHP 7.2 and all versions in between.
 
 ## Installation

--- a/tests/methods/ParseTest.php
+++ b/tests/methods/ParseTest.php
@@ -108,10 +108,6 @@ class ParseTest extends TestCase {
     }
 
     public function test_Piwik_data() {
-        if (!function_exists('array_column')) {
-            // function only available in PHP >= 5.5
-            return;
-        }
         $this->csv->use_mb_convert_encoding = true;
         $this->csv->output_encoding = 'UTF-8';
         $this->csv->auto(__DIR__ . '/../example_files/Piwik_API_download.csv');
@@ -134,12 +130,6 @@ class ParseTest extends TestCase {
      * @depends testSepRowAutoDetection
      */
     public function testGetColumnDatatypes() {
-        if (!function_exists('array_column')) {
-            // getDatatypes requires array_column, but that
-            // function is only available in PHP >= 5.5
-            return;
-        }
-
         $this->csv->auto(__DIR__ . '/fixtures/datatype.csv');
         $this->csv->getDatatypes();
         $expected = [
@@ -183,12 +173,6 @@ class ParseTest extends TestCase {
      * @depends testSepRowAutoDetection
      */
     public function testAutoDetectFileHasHeading() {
-        if (!function_exists('array_column')) {
-            // getDatatypes requires array_column, but that
-            // function is only available in PHP >= 5.5
-            return;
-        }
-
         $this->csv->auto(__DIR__ . '/fixtures/datatype.csv');
         $this->assertTrue($this->csv->autoDetectFileHasHeading());
 

--- a/tests/methods/ParseTest.php
+++ b/tests/methods/ParseTest.php
@@ -182,7 +182,7 @@ class ParseTest extends TestCase {
     /**
      * @depends testSepRowAutoDetection
      */
-    public function testAutoDetectFileHasHeading(){
+    public function testAutoDetectFileHasHeading() {
         if (!function_exists('array_column')) {
             // getDatatypes requires array_column, but that
             // function is only available in PHP >= 5.5


### PR DESCRIPTION
Because it is insecure and expensive to maintain support within this project.

The two specific problems with PHP 5.4 are
- no  `array_column()` function
- no autoloading if `::class` is used (it throws [this error](https://travis-ci.org/parsecsv/parsecsv-for-php/jobs/352205780#L482) which [won't happen on PHP 5.5 or newer](https://discourse.slimframework.com/t/parse-error-syntax-error-unexpected-class-t-class-expecting-identifier-t-string-or-variable-t-variable-or-or-in/646)

@susgo @jimeh @williamknauss I'll merge this on March 19 at the earliest unless you have concerns.