### PR TITLE
Replace fread with file_get_contents to avoid the 8192 byte limit

### DIFF
--- a/src/Csv.php
+++ b/src/Csv.php
@@ -1156,20 +1156,18 @@ class Csv {
     }
 
     /**
-     * Read local file
+     * Read local file.
      *
-     * @param string|null $file local filename
+     * @param string $file local filename
      *
      * @return string|false Data from file, or false on failure
      */
-    protected function _rfile($file = null) {
+    protected function _rfile($file) {
         if (is_readable($file)) {
-            if (!($fh = fopen($file, 'r'))) {
+            $data = file_get_contents($file);
+            if ($data === false) {
                 return false;
             }
-
-            $data = fread($fh, filesize($file));
-            fclose($fh);
             return rtrim($data, "\r\n");
         }
 


### PR DESCRIPTION
This can happen when using streams.

Specific problem occurred with a file uploaded with Drupal's ``managed_file``
Form API element.

See https://secure.php.net/manual/en/function.fread.php

@jimeh @waknauss This pull request is ready for review and merge. I'll go ahead and merge on August 7 or later if you lack the time.