### PR TITLE
Added example for writing CSV files to better document heading property

### DIFF
--- a/examples/save_to_file_without_header_row.php
+++ b/examples/save_to_file_without_header_row.php
@@ -1,0 +1,27 @@
+<?php
+
+
+# include parseCSV class.
+require __DIR__ . '/../vendor/autoload.php';
+
+use ParseCsv\Csv;
+
+
+# Create new parseCSV object.
+$csv = new Csv();
+
+# When saving, don't write the header row:
+$csv->heading = false;
+
+# Specify which columns to write, and in which order.
+# We won't output the 'Awesome' column this time.
+$csv->titles = ['Age', 'Name'];
+
+# Data to write:
+$csv->data = [
+    0 => ['Name' => 'Anne', 'Age' => 45, 'Awesome' => true],
+    1 => ['Name' => 'John', 'Age' => 44, 'Awesome' => false],
+];
+
+# Then we save the file to the file system:
+$csv->save('people.csv');


### PR DESCRIPTION
I'll need this example myself to remember how to use `$csv->title`.

Like the others, this example is executed by PHPUnit within our Travis CI. The CSV file will contain this headerless data:
````
45,Anne
44,John
````

Fixes #161