### PR TITLE
Added test for the case of objects as cells

### DIFF
--- a/src/Csv.php
+++ b/src/Csv.php
@@ -1137,7 +1137,7 @@ class Csv {
                 : '';
             $enclosure_quoted = preg_quote($this->enclosure, '/');
             $pattern = "/" . $delimiter_quoted . $enclosure_quoted . "|\n|\r/i";
-            if ($this->enclose_all || preg_match($pattern, $value) || (strpos($value, ' ') === 0 || substr($value, -1) == ' ')) {
+            if ($this->enclose_all || preg_match($pattern, $value) || strpos($value, ' ') === 0 || substr($value, -1) == ' ') {
                 $value = str_replace($this->enclosure, $this->enclosure . $this->enclosure, $value);
                 $value = $this->enclosure . $value . $this->enclosure;
             }

--- a/tests/methods/HasToString.php
+++ b/tests/methods/HasToString.php
@@ -1,9 +1,0 @@
-<?php
-
-
-namespace methods;
-
-
-class HasToString {
-
-}

--- a/tests/methods/HasToString.php
+++ b/tests/methods/HasToString.php
@@ -1,0 +1,9 @@
+<?php
+
+
+namespace methods;
+
+
+class HasToString {
+
+}

--- a/tests/methods/ObjectThatHasToStringMethod.php
+++ b/tests/methods/ObjectThatHasToStringMethod.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace ParseCsv\tests\methods;
+
+/**
+ * Class HasToString is just a helper to test if cells can be objects.
+ */
+class ObjectThatHasToStringMethod {
+
+    public function __toString() {
+        return 'some value';
+    }
+}

--- a/tests/methods/UnparseTest.php
+++ b/tests/methods/UnparseTest.php
@@ -88,6 +88,18 @@ class UnparseTest extends Testcase {
         $this->unparseAndCompare($expected);
     }
 
+    public function testObjectCells() {
+        $this->csv->data = [
+            [
+                'column1' => new ObjectThatHasToStringMethod(),
+                'column2' => 'boring',
+            ],
+        ];
+        $this->csv->linefeed = "\n";
+        $expected = "column1,column2\nsome value,boring\n";
+        $this->unparseAndCompare($expected);
+    }
+
     private function unparseAndCompare($expected, $fields = array()) {
         $str = $this->csv->unparse($this->csv->data, $fields);
         $this->assertEquals($expected, $str);


### PR DESCRIPTION
I encountered this in Drupal 8, where cells implemented the ``MarkupInterface``. It was objects that, when cast to a string, returned the translated string.

This new test is only green because of commit 5ca540daa74d1a0325d8d720b41014d726dfa81a.