### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+/.editorconfig export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/ChangeLog.txt export-ignore
+/examples export-ignore
+/Makefile export-ignore
+/ruleset.xml export-ignore
+/tests export-ignore


### PR DESCRIPTION
The `examples` and `tests/` directories should not be included in the Composer package since they are not needed in production scenarios and often become the source of security issues.