### PR TITLE
Fixing deprecated parse() to be parseFile()

### DIFF
--- a/src/Csv.php
+++ b/src/Csv.php
@@ -317,7 +317,7 @@ class Csv {
         $this->init($offset, $limit, $conditions, $keep_file_data);
 
         if (!empty($data)) {
-            $this->parse($data);
+            $this->parseFile($data);
         }
     }
 


### PR DESCRIPTION
i got this error when using laravel 7.x, and got error message. so, i'm changin it and it works fine in my local.